### PR TITLE
Add fiscal number toggle and company-level option

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "18.0.0.0.0",
+    "version": "18.0.1.0.0",
     "countries": ["do"],
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],

--- a/l10n_do_accounting/models/res_company.py
+++ b/l10n_do_accounting/models/res_company.py
@@ -15,10 +15,16 @@ class ResCompany(models.Model):
         "to have sales through offline mobile devices such as "
         "sales with Handheld, enter others.",
     )
+    l10n_do_disable_fiscal_documents = fields.Boolean(
+        string="Disable Fiscal Documents",
+        help="Disable Dominican fiscal document management for this company.",
+    )
 
     def _localization_use_documents(self):
         """Dominican localization uses documents"""
         self.ensure_one()
+        if self.l10n_do_disable_fiscal_documents:
+            return False
         return (
             True
             if self.country_id == self.env.ref("base.do")

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -65,6 +65,10 @@
                        invisible="not l10n_latam_use_documents or (move_type != 'out_invoice' or country_code != 'DO')"
                        required="l10n_latam_use_documents and move_type == 'out_invoice'"
                        readonly="state != 'draft'"/>
+                <field name="l10n_latam_manual_document_number" widget="boolean_toggle"
+                       string="Manual Fiscal Number"
+                       attrs="{'readonly': [('state','!=','draft')],
+                               'invisible': ['|', ('l10n_latam_use_documents','=',False), ('country_code','!=','DO')]}"/>
                 <field name="l10n_do_expense_type"
                        invisible="not l10n_latam_use_documents or (move_type != 'in_invoice' or country_code != 'DO')"
                        required="l10n_latam_use_documents and move_type == 'in_invoice'"

--- a/l10n_do_accounting/views/res_company_views.xml
+++ b/l10n_do_accounting/views/res_company_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="vat" position="after">
                 <field name="l10n_do_ecf_issuer" invisible="country_code != 'DO'"/>
+                <field name="l10n_do_disable_fiscal_documents" invisible="country_code != 'DO'"/>
                 <field name="l10n_do_ecf_deferred_submissions" groups="base.group_no_one" invisible="1"/>
                 <field name="l10n_do_dgii_start_date" invisible="1"/>
             </field>


### PR DESCRIPTION
## Summary
- add a switch to allow manual fiscal numbers on invoices
- allow disabling fiscal documents per company
- bump module version

## Testing
- `python3 -m flake8 . --count --exit-zero --select E9,F63,F7,F82 --ignore E203,E501,W503 --exclude __unported__,__init__.py,examples --show-source --statistics`
- `python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics`
- `python3 -m pylint $(git ls-files '*.py') --exit-zero --rcfile oca_pylint.cfg --load-plugins pylint_odoo`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68886fb5c85c8328bb83d307a6ced946